### PR TITLE
Add calculated distance to beacon JSON object

### DIFF
--- a/src/android/EstimoteBeacons.java
+++ b/src/android/EstimoteBeacons.java
@@ -157,6 +157,7 @@ public class EstimoteBeacons extends CordovaPlugin {
         object.put("rssi", beacon.getRssi());
         object.put("macAddress", beacon.getMacAddress());
         object.put("measuredPower", beacon.getMeasuredPower());
+        object.put("distance", Utils.computeAccuracy(beacon));
         return object;
     }
 }


### PR DESCRIPTION
Adding the calculated distance to the JSON object prevents us from having to calculate it on the JS side.
